### PR TITLE
:truck: add production deployment capabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN ./install-packages.sh
 FROM common-base AS dependencies
 ENV PATH="/opt/venv/bin:$PATH"
 
-#     apt-get install build-essential -y
 COPY requirements.txt /app/
 
 RUN pip install --target /opt/packages -r requirements.txt
@@ -44,7 +43,7 @@ RUN pip install --target /opt/packages -r requirements.txt
 FROM common-base AS app-run
 COPY --from=dependencies /opt/packages /opt/packages
 ENV PYTHONPATH "${PYTHONPATH}:/opt/packages"
-# ENV  PYTHONPATH="$PYTHONPATH:/app/lemarche:/app/config"
+ENV PATH "${PATH}:/opt/packages/bin"
 COPY ./ark ./ark
 COPY ./ark_import ./ark_import
 COPY ./arklet ./arklet

--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ Happy minting, binding, and resolving!
 See arklet/settings.py for the full list of options to put in your config file.
 
 ## Deploying
+:warning: Django being Django, you have to test the _production_ build locally.
+Why ? In _development_ build (ie: with `debug` turned on) Django servers the static content, while in
+_production_ mode it doesn't. [Whitenoise](http://whitenoise.evans.io/en/stable/)
+is used to serve the static content in _production_.
+
+To simulate _production_ mode, just set `ARK_DEBUG` to `False` in your local environment's
+configuration (or build the _prod_ build target).
+
 ### With docker
 Using the provided Dockerfile (is you wish to set a build target, use `prod`, 
 but being the default target you can skip this), provide the following values

--- a/arklet/settings.py
+++ b/arklet/settings.py
@@ -31,6 +31,8 @@ env = environ.Env(
     ARKLET_SENTRY_TRANSACTIONS_PER_TRACE=(int, 1),
     ARKLET_STATIC_ROOT=(str, "static"),
     ARKLET_MEDIA_ROOT=(str, "media"),
+    COMPRESSION_ENABLED=(bool, True),
+
 )
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -62,11 +64,13 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "compressor",
     "ark.apps.ArkConfig",
 ]
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -168,9 +172,21 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 
 STATIC_URL = "/static/"
-
 STATIC_ROOT = env.str("ARKLET_STATIC_ROOT")
+STATICFILES_FINDERS = [
+    "django.contrib.staticfiles.finders.FileSystemFinder",
+    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
+    "compressor.finders.CompressorFinder",
+]
 
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STATICFILES_FINDERS += ["compressor.finders.CompressorFinder"]
+
+COMPRESS_ENABLED = env.bool("COMPRESSION_ENABLED")
+COMPRESS_OFFLINE = True
+COMPRESS_STORAGE = "compressor.storage.GzipCompressorFileStorage"
+
+# Media files
 MEDIA_ROOT = env.str("ARKLET_MEDIA_ROOT")
 
 # Default primary key field type

--- a/arklet/settings.py
+++ b/arklet/settings.py
@@ -54,6 +54,9 @@ ALLOWED_HOSTS = [
     "ark.archive.org",
 ]
 
+CSRF_TRUSTED_ORIGINS=[
+    'https://%s' % env("ARKLET_HOST")
+]
 
 # Application definition
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
         context: .
         target: dev
         dockerfile: ./Dockerfile
+    #command: tail -F /var/log/lastlog 
     command: /app/entrypoint.sh
     volumes:
       - ./ark:/app/ark

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,9 @@ black==21.9b0
 certifi==2021.10.8
 click==8.0.3
 Django==4.0.4
+django-appconf==1.0.5
+django-compressor==4.0
+django-environ==0.8.0
 gunicorn==20.1.0
 Jinja2==3.0.2
 MarkupSafe==2.0.1
@@ -14,10 +17,12 @@ platformdirs==2.4.0
 psycopg2-binary==2.9.1
 pytz==2021.3
 PyYAML==6.0
+rcssmin==1.1.0
 regex==2021.10.23
+rjsmin==1.2.0
 sentry-sdk==1.4.3
 sqlparse==0.4.2
 tomli==1.2.2
 typing-extensions==3.10.0.2
 urllib3==1.26.7
-django-environ==0.8.0
+whitenoise==6.0.0


### PR DESCRIPTION
Adding needed dependencies and configuration to make a production-ready deployment possible.

1. Use gunicorn for running the production server
2. Add [whitenoise](http://whitenoise.evans.io/en/stable/) to serve static content
3. Added compressor (always useful, can be used later on for css SASS)
4. Updated [README.md](./readme.md)